### PR TITLE
編集画面に食品名、日時、登録されている食品一覧追加

### DIFF
--- a/templates/edit_food.html
+++ b/templates/edit_food.html
@@ -4,6 +4,31 @@
     <body>
         {% block content %}
             <h1>食品エントリの編集</h1>
+
+            編集対象日付: {{ entry.date.strftime('%Y-%m-%d') }}<br>
+
+            食品名: {{ entry.food_name }}<br>
+
+            <h2>その日に登録されている食品の一覧</h2>
+
+            <ul>
+                {% if food_entries %}
+                    {% for food_entry in food_entries %}
+                        <li>
+                            食品名: {{ food_entry.food_name }},
+                            重さ: {{ food_entry.grams }}g,
+                            タンパク質: {{ food_entry.protein }}g,
+                            脂質: {{ food_entry.fat }}g,
+                            コレステロール: {{ food_entry.cholesterol }}mg,
+                            炭水化物: {{ food_entry.carbohydrates }}g,
+                            エネルギー: {{ food_entry.energy_kcal }}kcal
+                        </li>
+                    {% endfor %}
+                {% else %}
+                    <li>食品エントリがありません</li>
+                {% endif %}
+            </ul>
+
             {% if error_message %}
                 <p style="color: red;">{{ error_message }}</p>
             {% endif %}
@@ -13,7 +38,7 @@
                 {{ form.grams(size=32) }} <!-- Flask-WTF フォームフィールドを使用 -->
                 <button type="submit">更新</button>
             </form>
-            <p><a href="{{ url_for('main.dashboard') }}">ダッシュボードに戻る</a></p>              
+            <p><a href="{{ url_for('main.dashboard') }}">ダッシュボードに戻る</a></p>
         {% endblock %}
 
     </body>

--- a/views.py
+++ b/views.py
@@ -287,10 +287,23 @@ def edit_food(id):
             error_message = "新しいグラム数を入力してください"
     else:
         error_message = ""
+        
+    target_date = entry.date.date()
+    target_datetime_start = datetime.combine(target_date, datetime.min.time())
+    target_datetime_end = datetime.combine(target_date, datetime.max.time())
+
+    food_entries = FoodEntry.query.filter(
+        FoodEntry.user_id == entry.user_id, 
+        FoodEntry.date >= target_datetime_start, 
+        FoodEntry.date <= target_datetime_end
+    ).all()
+
+
+
 
     print("Entry object before render_template:", entry)
     return render_template(
-        "edit_food.html", entry=entry, error_message=error_message, form=form
+        "edit_food.html", entry=entry, error_message=error_message, form=form,food_entries=food_entries
     )
 
 


### PR DESCRIPTION
食品編集画面でどの食品がいつ登録されたものか、また編集した日に登録されている食品が表示されてなく、使用づらいという問題を解決する為、
編集対象日時、食品名、編集対象の日に登録されている食品の一覧(重さ、栄養素)の表示を追加しました。

変更点は
views.pyのedit_food関数で
特定の日付範囲内に存在する食品エントリをデータベースから取得するコードを追加してます。

edit_food.htmlで
編集対象日付、食品名、その日登録されている食品の一覧のコードを追加しました。

ご確認お願いいたします。
