### PR TITLE
履歴をテーブル化する

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -41,42 +41,52 @@
         </form>
     </div>
 
-    
-
-
-
-    <h2>履歴</h2>
-    {% for entry in entries %}
-        <div class="entry">
-            <h3>{{ entry.date }}</h3>
-            <p>エネルギー (kcal): <span>{{ entry.kcal }}</span></p>
-            <p>タンパク質: <span>{{ entry.protein }}</span></p>
-            <p>脂質: <span>{{ entry.fat }}</span></p>
-            <p>コレステロール: <span>{{ entry.cholesterol }}</span></p>
-            <p>炭水化物: <span>{{ entry.carbs }}</span></p>
-            <ul>
-            {% for food in entry.foods %}
-                <li>
-                    {{ food.food_name }} - {{ food.grams }} g</li>
-                    <form method="GET" action="/edit_food/{{ food.id }}" style="display: inline;">
-                        <button type="submit">修正</button>
-                    </form>
-                    <form method="POST" action="/delete_food/{{ food.id }}" style="display: inline;">
-                        <button type="submit">削除</button>
-                    </form>
-                </li>
-            {% endfor %}
-            </ul>
-        </div>
-    {% endfor %}
-
-    <form action="{{ url_for('main.logout') }}" method="POST">
-        <button type="submit" class="btn btn-danger">Logout</button>
-    </form>
-
+<h2>履歴</h2>
+<table border="1" style="border-collapse:collapse">
+    <thead>
+        <tr>
+            <th>年月日</th>
+            <th>カロリー (kcal)</th>
+            <th>タンパク質 (g)</th>
+            <th>脂質 (g)</th>
+            <th>コレステロール (mg)</th>
+            <th>炭水化物 (g)</th>
+            <th>食品</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for entry in entries %}
+            <tr>
+                <td>{{ entry.date }}</td>
+                <td>{{ entry.kcal }}</td>
+                <td>{{ entry.protein }}</td>
+                <td>{{ entry.fat }}</td>
+                <td>{{ entry.cholesterol }}</td>
+                <td>{{ entry.carbs }}</td>
+                <td>
+                    <ul>
+                        {% for food in entry.foods %}
+                            <li>
+                                {{ food.food_name }} ({{ food.grams }}g)
+                                <form method="GET" action="/edit_food/{{ food.id }}" style="display: inline;">
+                                    <button type="submit">編集</button>
+                                </form>
+                                <form method="POST" action="/delete_food/{{ food.id }}" style="display: inline;">
+                                    <button type="submit">削除</button>
+                                </form>
+                                
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
 
 </body>
-</html>  
+</html>
+
 
 <img src="data:image/png;base64,{{ encoded_image }}" alt="Nutrient Intake Graph">
 


### PR DESCRIPTION
ダッシュボードの履歴の部分を見やすくするために、
テーブルで表記するように修正しました。

変更点は
dashboard.htmlの履歴の部分を年月日、カロリー(kcal)、タンパク質(g)、脂質(g)、コレステロール(mg)、炭水化物(g)、食品という各列の見出しを作り、
各項目と編集、削除ボタンを表記するようにしました。
またテーブルの枠を１本線にしました。

ご確認お願いいたします。