### PR TITLE
marge修正

### DIFF
--- a/generate_graph.py
+++ b/generate_graph.py
@@ -157,10 +157,6 @@ def generate_graph(dates, protein, energy, fat, cholesterol, carbohydrates):
 
     fig.delaxes(axes[2,1])
 
-    fig.tight_layout()
-    plt.savefig("static/nutrient_intake.png")
-
-
 
     with BytesIO() as buffer:
         plt.savefig(buffer, format='png')


### PR DESCRIPTION
コンフリクトする際に不要なコードを削除できていないことが原因で実行できていない現状であったため、
generate_graph.pyのgenerate_graph関数の
fig.tight_layout()
    plt.savefig("static/nutrient_intake.png")
を削除しました。

======= 
     plt.figure() 
     plt.plot(dates, protein, label="Protein (g)") 
     plt.plot(dates, energy, label="Energy (kcal)") 
     plt.plot(dates, fat, label="Fat (g)") 
     plt.plot(dates, cholesterol, label="Cholesterol (mg)") 
     plt.plot(dates, carbohydrates, label="Carbohydrates (g)") 
  
     plt.title("Nutrient Intake Over Time") 
     plt.xlabel("Date") 
     plt.ylabel("Intake") 
     plt.xticks(rotation=45) 
     plt.legend() 
この部分は違うissueを作業している際にこのミスに気づき、git hubのcodeのページから直接修正してしまってました。

ご確認お願いいたします。